### PR TITLE
Fix missing incorrect answer text

### DIFF
--- a/src/features/exams/components/ExamResults/ResultsList.tsx
+++ b/src/features/exams/components/ExamResults/ResultsList.tsx
@@ -54,7 +54,7 @@ export const ResultsList = ({ exam, questions }: Props) => {
                         </Grid>
                         <Grid item xs={10}>
                           <Typography variant="body1">
-                            {q.selectedAnswerIndex ? q.answers[q.selectedAnswerIndex].text : "-"}
+                            {(q.selectedAnswerIndex !== -1) ? q.answers[q.selectedAnswerIndex].text : "-"}
                           </Typography>
                         </Grid>
                         <Grid item xs={2}>


### PR DESCRIPTION
Boolean check failing because it was checking `if (selectedAnswerIndex)` , so if the index was 0 it would fail (despite being a valid index).